### PR TITLE
fix(accordian): Fix infinite re-renders

### DIFF
--- a/src/demo/accordion-demo.tsx
+++ b/src/demo/accordion-demo.tsx
@@ -1,9 +1,13 @@
-import {Accordion, useAccordionStore} from '../components/accordion'
+import {Accordion} from '../components/accordion'
 
 export function AccordionDemo() {
-  console.log(useAccordionStore(store => store.activeEventKey))
   return (
-    <Accordion defaultActiveKey="header-1" isMulti isOpenAll allEventKeys={["header-1", "header-2"]}>
+    <Accordion
+      defaultActiveKey="header-1"
+      isMulti
+      isOpenAll
+      allEventKeys={['header-1', 'header-2']}
+    >
       <Accordion.Item eventKey="header-1">
         <Accordion.Header eventKey="header-1">
           Lorem ipsum dolor sit, amet consectetur adipisicing elit. Pariatur at explicabo optio


### PR DESCRIPTION
I initially used a Zustand store to manage the state for multiple accordions, but since Zustand creates a global store by default, all accordions were referring to the same state. I then tried using a useAccordianStoresHook to create separate store instances dynamically for each accordion, but it made accessibility more complex since every item needed a unique ID for identification.

To simplify things, I switched to using React Context instead, and it's working fine. It keeps the state scoped to each accordion instance without extra complexity. Let me know if you have any thoughts on this!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified and streamlined the Accordion component’s internal state management for better performance and reliability.
	- Enhanced error handling to ensure proper usage of Accordion sections.
- **Style**
	- Improved the demo’s readability by updating the formatting of component properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->