### PR TITLE
perf: tree-shakeable multi-file dist (preserveModules + sideEffects)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,22 @@
 {
   "name": "@hybr1d-tech/charizard",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "files": [
     "dist"
   ],
-  "main": "./dist/hybr1d-ui.js",
-  "module": "./dist/hybr1d-ui.js",
+  "main": "./dist/components/index.js",
+  "module": "./dist/components/index.js",
   "types": "./dist/index.d.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/hybr1d-ui.js"
-    }
+      "import": "./dist/components/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",
@@ -81,10 +85,10 @@
     "storybook-css-modules-preset": "^1.1.1",
     "typescript": "6.0.3",
     "vite": "catalog:",
-    "vite-plus": "catalog:",
     "vite-plugin-checker": "^0.14.4",
     "vite-plugin-dts": "5.0.3",
-    "vite-plugin-libcss": "^1.1.2"
+    "vite-plugin-lib-inject-css": "^2.2.2",
+    "vite-plus": "catalog:"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,9 +170,9 @@ importers:
       vite-plugin-dts:
         specifier: 5.0.3
         version: 5.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.0.1))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.60.1)(typescript@6.0.3)
-      vite-plugin-libcss:
-        specifier: ^1.1.2
-        version: 1.1.2(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3))
+      vite-plugin-lib-inject-css:
+        specifier: ^2.2.2
+        version: 2.2.2(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3))
       vite-plus:
         specifier: 'catalog:'
         version: 0.2.1(@types/node@26.0.1)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3))(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3)
@@ -181,6 +181,68 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@ast-grep/napi-darwin-arm64@0.36.3':
+    resolution: {integrity: sha512-uM0Hrm5gcHqaBL64ktmPBFMTorTlPKWsUfi0E2Cg09GJfeYWvZmicCqgd7qVtjURmQvFQdb4JSqHIkJvws6Uqw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/napi-darwin-x64@0.36.3':
+    resolution: {integrity: sha512-wEMeQw8lRL66puG2m8m0kDRQDtubygj59HA/cmut2V5SPx/13BN3wuEk6JPv97gqGUCUGhG2+5Z6UZ/Ll2q01Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/napi-linux-arm64-gnu@0.36.3':
+    resolution: {integrity: sha512-sMsTMaUjW7SM8KPbLviCSBuM4zgJcwvie1yZI92HKSlFzC7ABe7X7UvyUREB+JwqccDVEL5yOJAjqB8eFSCizw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/napi-linux-arm64-musl@0.36.3':
+    resolution: {integrity: sha512-2XRmNYuovZu0Pa4J3or4PKMkQZnXXfpVcCrPwWB/2ytX7XUo+TWLgYE8rPVnJOyw5zujkveFb0XUrro9mQgLzw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@ast-grep/napi-linux-x64-gnu@0.36.3':
+    resolution: {integrity: sha512-mTwPRbBi1feGqR2b5TWC5gkEDeRi8wfk4euF5sKNihfMGHj6pdfINHQ3QvLVO4C7z0r/wgWLAvditFA0b997dg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/napi-linux-x64-musl@0.36.3':
+    resolution: {integrity: sha512-tMGPrT+zuZzJK6n1cD1kOii7HYZE9gUXjwtVNE/uZqXEaWP6lmkfoTMbLjnxEe74VQbmaoDGh1/cjrDBnqC6Uw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@ast-grep/napi-win32-arm64-msvc@0.36.3':
+    resolution: {integrity: sha512-7pFyr9+dyV+4cBJJ1I57gg6PDXP3GBQeVAsEEitzEruxx4Hb4cyNro54gGtlsS+6ty+N0t004tPQxYO2VrsPIg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/napi-win32-ia32-msvc@0.36.3':
+    resolution: {integrity: sha512-MPAgccH9VscRaFuEBMzDGPS+3c4cKNVGIVJ7WSNa1nZtLQ0eFEaPJ7pyDnCezgVSxfNFVYBvKyyF/vcm7Qc9+A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/napi-win32-x64-msvc@0.36.3':
+    resolution: {integrity: sha512-TIVtuSbXhty9kaSEfr4ULWx5PAuUeGgUkFaR60lmOs7sGTWgpig+suwKfTmevoAblFknCW/aMHOwziwJoUZA6A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/napi@0.36.3':
+    resolution: {integrity: sha512-ExypohE8L7FvKBHxu7UpwcV9XVfyS+AqNZKyKIfxYwJyD9l7Gw6pmMYd7J2uopJsPEIUf44/emEFds6nFUx/dw==}
+    engines: {node: '>= 10'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -2023,9 +2085,6 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2034,9 +2093,6 @@ packages:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -2532,10 +2588,6 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
-
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -3085,8 +3137,8 @@ packages:
       vite:
         optional: true
 
-  vite-plugin-libcss@1.1.2:
-    resolution: {integrity: sha512-nM1vqIibhKPvzpa6aPc8DahGcKS82cUE/Jiap6r9aIrsNno105RIDI8XnLmP1nKU8nhGb08eNrWjSOhO53c6NQ==}
+  vite-plugin-lib-inject-css@2.2.2:
+    resolution: {integrity: sha512-NF30p0GwtfSAmVlxo2NgPXM2rEdtgV7LFi4lkzajKD7P3Ru/ZAFmI533M0Z5qyMZpvNMxVGkewzpjD0HOWtbDQ==}
     peerDependencies:
       vite: '*'
 
@@ -3199,6 +3251,45 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@ast-grep/napi-darwin-arm64@0.36.3':
+    optional: true
+
+  '@ast-grep/napi-darwin-x64@0.36.3':
+    optional: true
+
+  '@ast-grep/napi-linux-arm64-gnu@0.36.3':
+    optional: true
+
+  '@ast-grep/napi-linux-arm64-musl@0.36.3':
+    optional: true
+
+  '@ast-grep/napi-linux-x64-gnu@0.36.3':
+    optional: true
+
+  '@ast-grep/napi-linux-x64-musl@0.36.3':
+    optional: true
+
+  '@ast-grep/napi-win32-arm64-msvc@0.36.3':
+    optional: true
+
+  '@ast-grep/napi-win32-ia32-msvc@0.36.3':
+    optional: true
+
+  '@ast-grep/napi-win32-x64-msvc@0.36.3':
+    optional: true
+
+  '@ast-grep/napi@0.36.3':
+    optionalDependencies:
+      '@ast-grep/napi-darwin-arm64': 0.36.3
+      '@ast-grep/napi-darwin-x64': 0.36.3
+      '@ast-grep/napi-linux-arm64-gnu': 0.36.3
+      '@ast-grep/napi-linux-arm64-musl': 0.36.3
+      '@ast-grep/napi-linux-x64-gnu': 0.36.3
+      '@ast-grep/napi-linux-x64-musl': 0.36.3
+      '@ast-grep/napi-win32-arm64-msvc': 0.36.3
+      '@ast-grep/napi-win32-ia32-msvc': 0.36.3
+      '@ast-grep/napi-win32-x64-msvc': 0.36.3
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -4805,15 +4896,9 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.10
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.40: {}
-
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.7:
     dependencies:
@@ -5237,10 +5322,6 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
-
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.1.1
 
   minimist@1.2.8: {}
 
@@ -5843,9 +5924,11 @@ snapshots:
       - typescript
       - webpack
 
-  vite-plugin-libcss@1.1.2(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3)):
+  vite-plugin-lib-inject-css@2.2.2(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3)):
     dependencies:
-      minimatch: 9.0.9
+      '@ast-grep/napi': 0.36.3
+      magic-string: 0.30.21
+      picocolors: 1.1.1
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3)'
 
   vite-plus@0.2.1(@types/node@26.0.1)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@26.0.1)(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3))(esbuild@0.28.1)(typescript@6.0.3)(yaml@1.10.3):

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -7,17 +7,10 @@ import clsx from 'clsx'
 import {format, isDate, parseISO} from 'date-fns'
 import {DayPicker, DropdownOption, Matcher, PropsSingle, useDayPicker} from 'react-day-picker'
 import {Placement} from '@popperjs/core'
-import {
-  SVG,
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-  SelectV2,
-  Button,
-  BUTTON_TYPE,
-  BUTTON_SIZE,
-  BUTTON_VARIANT,
-} from '../index'
+import {SVG} from '../svg'
+import {Popover, PopoverTrigger, PopoverContent} from '../popover'
+import {SelectV2} from '../select-v2'
+import {BUTTON_SIZE, BUTTON_TYPE, BUTTON_VARIANT, Button} from '../button'
 import {StylesConfig} from 'react-select'
 import {create} from 'zustand'
 import {DateStore, MonthYear} from './type'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,4 @@
-import './styles/_typography.css'
-import './styles/_variables.css'
-import './styles/global.css'
-import './toasts/styles/main.css'
+import './styles/index.css'
 
 export * from '../types'
 export * from '../hooks'

--- a/src/components/styles/index.css
+++ b/src/components/styles/index.css
@@ -1,0 +1,7 @@
+/* Global library styles, aggregated so the build injects them as ONE css
+   import on the entry chunk with a deterministic cascade order.
+   (Separate JS imports get injected in unspecified order by libInjectCss.) */
+@import './_typography.css';
+@import './_variables.css';
+@import './global.css';
+@import '../toasts/styles/main.css';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,12 @@
 import react from '@vitejs/plugin-react-swc'
 import dts from 'vite-plugin-dts'
-import libCss from 'vite-plugin-libcss'
+import {libInjectCss} from 'vite-plugin-lib-inject-css'
 import checker from 'vite-plugin-checker'
 import pkg from './package.json'
 import {resolve} from 'node:path'
 import {defineConfig} from 'vite'
+
+const peers = Object.keys(pkg.peerDependencies)
 
 export default defineConfig({
   plugins: [
@@ -14,17 +16,33 @@ export default defineConfig({
       insertTypesEntry: true, // Insert type entry file in the package
       tsconfigPath: './tsconfig.app.json', // Points to your tsconfig
     }),
-    libCss(),
+    // Injects each chunk's own CSS import (replaces vite-plugin-libcss).
+    // With preserveModules, consumers only load CSS for the components they
+    // bundle; the four global styles stay on the entry chunk because they're
+    // imported at the top of components/index.ts.
+    libInjectCss(),
     checker({typescript: true}),
   ],
   build: {
     lib: {
       entry: resolve(__dirname, 'src/components/index.ts'),
-      fileName: 'hybr1d-ui',
       formats: ['es'],
     },
-    rollupOptions: {
-      external: [...Object.keys(pkg.peerDependencies)],
+    cssCodeSplit: true,
+    rolldownOptions: {
+      // Prefix-match so dep subpaths (e.g. zustand/middleware) are
+      // externalized too — exact matching used to silently bundle them.
+      external: (id: string) => peers.some(p => id === p || id.startsWith(p + '/')),
+      output: {
+        // One output module per source module: consumers tree-shake per
+        // component, and their bundlers place each module in the chunk where
+        // it's used (eager shell vs lazy routes) instead of keeping the whole
+        // library in the startup bundle.
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+        entryFileNames: '[name].js',
+        assetFileNames: 'assets/[name]-[hash][extname]',
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary

Ships the library as **preserved modules** (283 files mirroring `src/`) instead of a single 1.2 MB bundle, with `"sideEffects": ["**/*.css"]`. Consumer bundlers can now tree-shake per component and place each module in the chunk where it's used — the entire library (plus react-select, react-day-picker, @tanstack/react-table, @dnd-kit, @zag-js/color-picker) no longer lands in every consumer's startup chunk.

**No consumer-facing API change**: root named imports (`import {Button} from '@hybr1d-tech/charizard'`) work unchanged; global theme CSS still auto-loads via the entry chunk. No consumer deep-imports the old `dist/hybr1d-ui.js` path (verified across all 3 consumers).

## Changes

- `vite.config.ts`: `rolldownOptions.output.preserveModules` (+ `preserveModulesRoot: 'src'`), hashed asset names, `external()` now **prefix-matches** peers — this also fixes a latent bug where `zustand/middleware` was silently bundled into the dist
- `vite-plugin-libcss` → `vite-plugin-lib-inject-css`: per-chunk CSS imports, so unused components' CSS is dropped by consumers
- Global styles (`_typography`, `_variables`, `global`, toast styles) aggregated into `src/components/styles/index.css` — one deterministic cascade-order import on the entry chunk (separate JS imports were injected in reversed order)
- `DatePicker.tsx`: direct component imports replace the `'../index'` root-barrel self-import (a cycle that defeated tree-shaking)
- `package.json`: v2.7.0, entry `dist/components/index.js`, `sideEffects`, exports map + `./package.json` export
- Types unchanged: single bundled `dist/index.d.ts`

## Measured impact (packed tarball against hybr1d-frontend `perf/pageload-optimizations`)

| | before (2.4.2) | after (2.7.0) |
|---|---|---|
| Eager JS (min) | 2,060 KB | **1,051 KB** |
| Eager JS (gzip) | 658 KB | **349 KB** |
| charizard eager source | 1,135 KB | 323 KB* |
| react-select / day-picker / tanstack-table / dnd-kit / color-picker in eager graph | yes | **none** |

\* 299 KB of the remainder is one base64 illustration (`sleeping-user.svg`) pulled by the eagerly-routed `ErrorsPage` — will be addressed by lazy-loading the error route in the consumer.

## Verification

- Dist sanity: zero inlined node_modules; `zustand/middleware` external; DatePicker imports specific modules; global CSS aggregate first on the entry chunk
- Console app: `vp dev` boots (multi-file dep prebundles fine), production build green, headless Chrome screenshot of the login page pixel-correct (fonts, CSS variables, buttons, inputs)

## Rollout

Tag `v2.7.0` after merge (CI publishes on `v*` tags). Consumers upgrade console-first via `vp run ui:up` (two-step through 2.6.0 to isolate unrelated product changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library styles are now bundled through a single shared stylesheet, improving consistent styling when the package is consumed.
  * Published package entry points were updated to match the new component-based build output.

* **Bug Fixes**
  * CSS assets are now marked as side effects so styles are retained correctly in consuming apps.
  * External package handling now covers nested imports more reliably during builds.

* **Chores**
  * Updated the package version to 2.7.0 and refreshed build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->