### PR TITLE
chore: stable chunk names + gate npm publish to tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build
         run: vp run build
       - name: Publish Package
+        # publish only on v* tag pushes — PR runs are CI-only (a PR run once
+        # published a version before the tag did)
+        if: startsWith(github.ref, 'refs/tags/v')
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -39,7 +42,7 @@ jobs:
           channel: '#alerts-deploys'
           message:
             'Charizard was successfully published to npm'
-        if: success()
+        if: success() && startsWith(github.ref, 'refs/tags/v')
       - name: slack - build failed
         uses: act10ns/slack@v2.2.0
         with:
@@ -47,4 +50,4 @@ jobs:
           channel: '#alerts-deploys'
           message:
             'Charizard has failed to publish to npm'
-        if: failure()
+        if: failure() && startsWith(github.ref, 'refs/tags/v')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,8 @@ export default defineConfig({
         preserveModules: true,
         preserveModulesRoot: 'src',
         entryFileNames: '[name].js',
+        // stable name if a plugin ever emits a helper chunk (none do today)
+        chunkFileNames: '[name].js',
         assetFileNames: 'assets/[name]-[hash][extname]',
       },
     },


### PR DESCRIPTION
## Summary

Two small hardening items following up on #298:

1. **`chunkFileNames: '[name].js'`** (from the #298 review): with `preserveModules`, helper/virtual chunks emitted by plugins would fall back to hashed default names. Verified no such chunks exist today (all 283 dist JS files map 1:1 to source modules), so this is pure future-proofing — a stable name beats a hash that churns the package on every release. Dist output is byte-identical.

2. **Publish only on tag pushes**: the workflow previously ran `npm publish` on `pull_request` events too — that's how 2.7.0 reached npm from the PR's CI run before the `v2.7.0` tag run, which then failed as a duplicate. A PR from any branch could publish unreviewed code. The publish and Slack steps are now gated on `refs/tags/v*`; PR runs still install + build as CI.

No release needed — the config change ships with whatever version goes out next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)